### PR TITLE
Modified npmignore for custom builds througn npm

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,8 +1,5 @@
-src/
-lib/
 dist/all.min.js
 dist/all.min.js.gz
 dist/fabric.min.js
 dist/fabric.min.js.gz
 .DS_Store
-HEADER.js


### PR DESCRIPTION
Right now, if you install Fabric through `npm install`you can't do a build with gestures, which is quite frustrant and completly unnecesary!